### PR TITLE
Add some manifests for simplifying development

### DIFF
--- a/k8s/overlays/branch_build/kustomization.yaml
+++ b/k8s/overlays/branch_build/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+  - ../../xdmod-build
+patchesStrategicMerge:
+  - patches/bc-xdmod.yaml

--- a/k8s/overlays/branch_build/patches/bc-xdmod-dev.yaml
+++ b/k8s/overlays/branch_build/patches/bc-xdmod-dev.yaml
@@ -1,0 +1,10 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: bc-xdmod-dev
+spec:
+  runPolicy: Serial
+  source:
+    type: Git
+    git:
+      ref: DataJob

--- a/k8s/overlays/branch_build/patches/bc-xdmod.yaml
+++ b/k8s/overlays/branch_build/patches/bc-xdmod.yaml
@@ -1,0 +1,10 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: bc-xdmod
+spec:
+  runPolicy: Serial
+  source:
+    type: Git
+    git:
+      ref: DataJob

--- a/k8s/overlays/xdmod-dev/kustomization.yaml
+++ b/k8s/overlays/xdmod-dev/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+  - ../../kube-base
+patchesStrategicMerge:
+  - patches/deployment-xdmod.yaml

--- a/k8s/overlays/xdmod-dev/patches/deployment-xdmod.yaml
+++ b/k8s/overlays/xdmod-dev/patches/deployment-xdmod.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - image: moc-xdmod-dev
+          name: xdmod
+          imagePullPolicy: Never
+          volumeMounts:
+            - name: vol-xdmod-src
+              mountPath: /usr/share/xdmod
+      initContainers:
+        - image: moc-xdmod-dev
+          name: xdmod-init-1
+          volumeMounts:
+            - name: vol-xdmod-src
+              mountPath: /mnt/xdmod_src
+        - image: moc-xdmod-dev
+          name: xdmod-init-2
+          volumeMounts:
+            - name: vol-xdmod-src
+              mountPath: /usr/share/xdmod
+      volumes:
+        - name: vol-xdmod-src
+          persistentVolumeClaim:
+            claimName: pvc-xdmod-src

--- a/k8s/xdmod-build/bc-xdmod.yaml
+++ b/k8s/xdmod-build/bc-xdmod.yaml
@@ -8,7 +8,6 @@ spec:
     type: Git
     git:
       uri: https://github.com/CCI-MOC/xdmod-cntr.git
-      ref: XdmodK8sDeployment
     contextDir: /
   strategy:
     type: Docker


### PR DESCRIPTION
This PR adds some kustomize overlays to simplify the task of deploying development versions of the xdmod container.