### PR TITLE
Use configmaped files for mariadb configuration

### DIFF
--- a/k8s/kube-base/deployment-mariadb.yaml
+++ b/k8s/kube-base/deployment-mariadb.yaml
@@ -25,7 +25,34 @@ spec:
           volumeMounts:
             - name: vol-mariadb
               mountPath: /var/lib/mysql
+            - name: vol-my-conf
+              mountPath: /etc/mysql/my.cnf
+              subPath: my.cnf
+            - name: vol-mariadb-conf
+              mountPath: /etc/mysql/mariadb.cnf
+              subPath: mariadb.cnf
+            - name: vol-mysql-safe-conf
+              mountPath: /etc/mysql/conf.d/mysqld_safe_syslog.cnf
+              subPath: mysqld_safe_syslog.cnf
       volumes:
         - name: vol-mariadb
           persistentVolumeClaim:
             claimName: pvc-mariadb
+        - name: vol-my-conf
+          configMap:
+            name: cm-my-conf
+            items:
+              - key: etc-mysql-my.cnf
+                path: my.cnf
+        - name: vol-mariadb-conf
+          configMap:
+            name: cm-mariadb-conf
+            items:
+              - key: etc-mysql-mariadb.cnf
+                path: mariadb.cnf
+        - name: vol-mysql-safe-conf
+          configMap:
+            name: cm-mysql-safe-conf
+            items:
+              - key: etc-mysql-conf.d-mysqld_safe_syslog.cnf
+                path: mysqld_safe_syslog.cnf

--- a/k8s/kube-base/deployment-mariadb.yaml
+++ b/k8s/kube-base/deployment-mariadb.yaml
@@ -25,34 +25,19 @@ spec:
           volumeMounts:
             - name: vol-mariadb
               mountPath: /var/lib/mysql
-            - name: vol-my-conf
+            - name: vol-mariadb-conf
               mountPath: /etc/mysql/my.cnf
               subPath: my.cnf
             - name: vol-mariadb-conf
               mountPath: /etc/mysql/mariadb.cnf
               subPath: mariadb.cnf
-            - name: vol-mysql-safe-conf
+            - name: vol-mariadb-conf
               mountPath: /etc/mysql/conf.d/mysqld_safe_syslog.cnf
               subPath: mysqld_safe_syslog.cnf
       volumes:
         - name: vol-mariadb
           persistentVolumeClaim:
             claimName: pvc-mariadb
-        - name: vol-my-conf
-          configMap:
-            name: cm-my-conf
-            items:
-              - key: etc-mysql-my.cnf
-                path: my.cnf
         - name: vol-mariadb-conf
           configMap:
             name: cm-mariadb-conf
-            items:
-              - key: etc-mysql-mariadb.cnf
-                path: mariadb.cnf
-        - name: vol-mysql-safe-conf
-          configMap:
-            name: cm-mysql-safe-conf
-            items:
-              - key: etc-mysql-conf.d-mysqld_safe_syslog.cnf
-                path: mysqld_safe_syslog.cnf

--- a/k8s/kube-base/kustomization.yaml
+++ b/k8s/kube-base/kustomization.yaml
@@ -23,15 +23,11 @@ configMapGenerator:
   - name: cm-httpd-conf
     files:
       - httpd.conf
-  - name: cm-my-conf
-    files:
-      - mariadb-conf/etc-mysql-my.cnf
   - name: cm-mariadb-conf
     files:
-      - mariadb-conf/etc-mysql-mariadb.cnf
-  - name: cm-mysql-safe-conf
-    files:
-      - mariadb-conf/etc-mysql-conf.d-mysqld_safe_syslog.cnf
+      - my.cnf=mariadb-conf/etc-mysql-my.cnf
+      - mariadb.cnf=mariadb-conf/etc-mysql-mariadb.cnf
+      - mysqld_safe_syslog.cnf=mariadb-conf/etc-mysql-conf.d-mysqld_safe_syslog.cnf
 generatorOptions:
   disableNameSuffixHash: true
   labels:

--- a/k8s/kube-base/kustomization.yaml
+++ b/k8s/kube-base/kustomization.yaml
@@ -23,10 +23,18 @@ configMapGenerator:
   - name: cm-httpd-conf
     files:
       - httpd.conf
+  - name: cm-my-conf
+    files:
+      - mariadb-conf/etc-mysql-my.cnf
+  - name: cm-mariadb-conf
+    files:
+      - mariadb-conf/etc-mysql-mariadb.cnf
+  - name: cm-mysql-safe-conf
+    files:
+      - mariadb-conf/etc-mysql-conf.d-mysqld_safe_syslog.cnf
 generatorOptions:
   disableNameSuffixHash: true
   labels:
     type: generated
   annotations:
     note: generated
-

--- a/k8s/kube-base/mariadb-conf/etc-mysql-conf.d-mysqld_safe_syslog.cnf
+++ b/k8s/kube-base/mariadb-conf/etc-mysql-conf.d-mysqld_safe_syslog.cnf
@@ -1,0 +1,4 @@
+# from configmap
+[mysqld_safe]
+skip_log_error
+syslog

--- a/k8s/kube-base/mariadb-conf/etc-mysql-mariadb.cnf
+++ b/k8s/kube-base/mariadb-conf/etc-mysql-mariadb.cnf
@@ -1,0 +1,19 @@
+# MariaDB-specific config file - from configmap
+# Read by /etc/mysql/my.cnf
+
+[client]
+# Default is Latin1, if you need UTF-8 set this (also in server section)
+#default-character-set = utf8 
+
+[mysqld]
+#
+# * Character sets
+# 
+# Default is Latin1, if you need UTF-8 set all this (also in client section)
+#
+#character-set-server  = utf8 
+#collation-server      = utf8_general_ci 
+#character_set_server   = utf8 
+#collation_server       = utf8_general_ci 
+# Import all .cnf files from configuration directory
+!includedir /etc/mysql/mariadb.conf.d/

--- a/k8s/kube-base/mariadb-conf/etc-mysql-mariadb.cnf
+++ b/k8s/kube-base/mariadb-conf/etc-mysql-mariadb.cnf
@@ -1,4 +1,5 @@
-# MariaDB-specific config file - from configmap
+# from configmap
+# MariaDB-specific config file
 # Read by /etc/mysql/my.cnf
 
 [client]

--- a/k8s/kube-base/mariadb-conf/etc-mysql-my.cnf
+++ b/k8s/kube-base/mariadb-conf/etc-mysql-my.cnf
@@ -1,0 +1,191 @@
+# MariaDB database server configuration file.
+# 
+# This is from the configmap mounted to /etc/mysql/my.cnf
+# overlaying the my.cnf file that is there
+# 
+# One can use all long options that the program supports.
+# Run program with --help to get a list of available options and with
+# --print-defaults to see which it would actually understand and use.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+# This will be passed to all mysql clients
+# It has been reported that passwords should be enclosed with ticks/quotes
+# escpecially if they contain "#" chars...
+# Remember to edit /etc/mysql/debian.cnf when changing the socket location.
+[client]
+port		= 3306
+socket		= /var/run/mysqld/mysqld.sock
+
+# Here is entries for some specific programs
+# The following values assume you have at least 32M ram
+
+# This was formally known as [safe_mysqld]. Both versions are currently parsed.
+[mysqld_safe]
+socket		= /var/run/mysqld/mysqld.sock
+nice		= 0
+
+[mysqld]
+#
+# * Basic Settings
+#
+#user		= mysql
+pid-file	= /var/run/mysqld/mysqld.pid
+socket		= /var/run/mysqld/mysqld.sock
+port		= 3306
+basedir		= /usr
+datadir		= /var/lib/mysql
+tmpdir		= /tmp
+lc_messages_dir	= /usr/share/mysql
+lc_messages	= en_US
+skip-external-locking
+#
+# Instead of skip-networking the default is now to listen only on
+# localhost which is more compatible and is not less secure.
+#bind-address		= 127.0.0.1
+#
+# * Fine Tuning
+#
+max_connections		= 100
+connect_timeout		= 5
+wait_timeout		= 600
+max_allowed_packet	= 16M
+thread_cache_size       = 128
+sort_buffer_size	= 4M
+bulk_insert_buffer_size	= 16M
+tmp_table_size		= 32M
+max_heap_table_size	= 32M
+#
+# * MyISAM
+#
+# This replaces the startup script and checks MyISAM tables if needed
+# the first time they are touched. On error, make copy and try a repair.
+myisam_recover_options = BACKUP
+key_buffer_size		= 128M
+#open-files-limit	= 2000
+table_open_cache	= 400
+myisam_sort_buffer_size	= 512M
+concurrent_insert	= 2
+read_buffer_size	= 2M
+read_rnd_buffer_size	= 1M
+#
+# * Query Cache Configuration
+#
+# Cache only tiny result sets, so we can fit more in the query cache.
+query_cache_limit		= 128K
+query_cache_size		= 64M
+# for more write intensive setups, set to DEMAND or OFF
+#query_cache_type		= DEMAND
+#
+# * Logging and Replication
+#
+# Both location gets rotated by the cronjob.
+# Be aware that this log type is a performance killer.
+# As of 5.1 you can enable the log at runtime!
+#general_log_file        = /var/log/mysql/mysql.log
+#general_log             = 1
+#
+# Error logging goes to syslog due to /etc/mysql/conf.d/mysqld_safe_syslog.cnf.
+#
+# we do want to know about network errors and such
+#log_warnings		= 2
+#
+# Enable the slow query log to see queries with especially long duration
+#slow_query_log[={0|1}]
+slow_query_log_file	= /var/log/mysql/mariadb-slow.log
+long_query_time = 10
+#log_slow_rate_limit	= 1000
+#log_slow_verbosity	= query_plan
+
+#log-queries-not-using-indexes
+#log_slow_admin_statements
+#
+# The following can be used as easy to replay backup logs or for replication.
+# note: if you are setting up a replication slave, see README.Debian about
+#       other settings you may need to change.
+#server-id		= 1
+#report_host		= master1
+#auto_increment_increment = 2
+#auto_increment_offset	= 1
+#log_bin			= /var/log/mysql/mariadb-bin
+#log_bin_index		= /var/log/mysql/mariadb-bin.index
+# not fab for performance, but safer
+#sync_binlog		= 1
+expire_logs_days	= 10
+max_binlog_size         = 100M
+# slaves
+#relay_log		= /var/log/mysql/relay-bin
+#relay_log_index	= /var/log/mysql/relay-bin.index
+#relay_log_info_file	= /var/log/mysql/relay-bin.info
+#log_slave_updates
+#read_only
+#
+# If applications support it, this stricter sql_mode prevents some
+# mistakes like inserting invalid dates etc.
+#sql_mode		= NO_ENGINE_SUBSTITUTION,TRADITIONAL
+#
+# * InnoDB
+#
+# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
+# Read the manual for more InnoDB related options. There are many!
+default_storage_engine	= InnoDB
+innodb_buffer_pool_size	= 256M
+innodb_log_buffer_size	= 8M
+innodb_file_per_table	= 1
+innodb_open_files	= 400
+innodb_io_capacity	= 400
+innodb_flush_method	= O_DIRECT
+#
+# * Security Features
+#
+# Read the manual, too, if you want chroot!
+# chroot = /var/lib/mysql/
+#
+# For generating SSL certificates I recommend the OpenSSL GUI "tinyca".
+#
+# ssl-ca=/etc/mysql/cacert.pem
+# ssl-cert=/etc/mysql/server-cert.pem
+# ssl-key=/etc/mysql/server-key.pem
+
+#
+# * Galera-related settings
+#
+[galera]
+# Mandatory settings
+#wsrep_on=ON
+#wsrep_provider=
+#wsrep_cluster_address=
+#binlog_format=row
+#default_storage_engine=InnoDB
+#innodb_autoinc_lock_mode=2
+#
+# Allow server to accept connections on all interfaces.
+#
+#bind-address=0.0.0.0
+#
+# Optional setting
+#wsrep_slave_threads=1
+#innodb_flush_log_at_trx_commit=0
+
+[mysqldump]
+quick
+quote-names
+max_allowed_packet	= 16M
+
+[mysql]
+#no-auto-rehash	# faster start of mysql but no tab completion
+
+[isamchk]
+key_buffer		= 16M
+
+#
+# * IMPORTANT: Additional settings that can override those from this file!
+#   The files must end with '.cnf', otherwise they'll be ignored.
+#
+!include /etc/mysql/mariadb.cnf
+[mariadb]
+skip-host-cache
+skip-name-resolve
+
+!includedir /etc/mysql/conf.d/

--- a/k8s/kube-base/mariadb-conf/etc-mysql-my.cnf
+++ b/k8s/kube-base/mariadb-conf/etc-mysql-my.cnf
@@ -1,6 +1,7 @@
+# from configmap
 # MariaDB database server configuration file.
 # 
-# This is from the configmap mounted to /etc/mysql/my.cnf
+# This is from /etc/mysql/my.cnf
 # overlaying the my.cnf file that is there
 # 
 # One can use all long options that the program supports.


### PR DESCRIPTION
This resolves (https://github.com/CCI-MOC/xdmod-cntr/issues/63)

To summarize, using configmaps for the mariadb configuration allows
for tuning parameters to adjust for the enfironment that mariadb is
running in.