### PR TITLE
Need to include the yaml to add the namespace for Argo CD

### DIFF
--- a/k8s/kube-base/kustomization.yaml
+++ b/k8s/kube-base/kustomization.yaml
@@ -3,6 +3,7 @@ commonLabels:
 namespace: xdmod
 
 resources:
+  - ns-xdmod.yaml
   - pvc-mariadb.yaml
   - pvc-xdmod-conf.yaml
   - pvc-xdmod-src.yaml

--- a/k8s/overlays/nerc-ocp-infra/patches/bc-xdmod-dev.yaml
+++ b/k8s/overlays/nerc-ocp-infra/patches/bc-xdmod-dev.yaml
@@ -6,4 +6,4 @@ spec:
   source:
     type: Git
     git:
-      ref: ArgoDeploy
+      ref: IncludeNamespace

--- a/k8s/overlays/nerc-ocp-infra/patches/bc-xdmod.yaml
+++ b/k8s/overlays/nerc-ocp-infra/patches/bc-xdmod.yaml
@@ -6,4 +6,4 @@ spec:
   source:
     type: Git
     git:
-      ref: ArgoDeploy
+      ref: IncludeNamespace


### PR DESCRIPTION
I had figured that argo cd created namespaces from the namespace
defined in other files as I was able to find the xdmod project in the
openshift UI.  However, this incorrect.

Adding this as Justin found the following error:

    Failed sync attempt to 5c594eeb996faf241c9ce67d7967b3428fb8a4e8:
    one or more objects failed to apply,
    reason: namespaces "xdmod" not found (retried 5 times).