### PR TITLE
Added time to the connection_timeout

### DIFF
--- a/k8s/kube-base/mariadb-conf/etc-mysql-my.cnf
+++ b/k8s/kube-base/mariadb-conf/etc-mysql-my.cnf
@@ -49,7 +49,7 @@ skip-external-locking
 # * Fine Tuning
 #
 max_connections		= 100
-connect_timeout		= 5
+connect_timeout		= 120
 wait_timeout		= 600
 max_allowed_packet	= 16M
 thread_cache_size       = 128


### PR DESCRIPTION
We are having a connection_timeout problem in nerc-shift-0-infra and in ocp-staging.  By increasing the connection_timeout we can continue processing while we figureout the undlying issue.