### PR TITLE
Correct validation errors in CronJobs

### DIFF
--- a/k8s/kube-base/cron-job-xdmod-ingestor.yaml
+++ b/k8s/kube-base/cron-job-xdmod-ingestor.yaml
@@ -6,6 +6,7 @@ spec:
   schedule: "@daily"
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         spec:
           containers:
@@ -24,7 +25,6 @@ spec:
                 - name: vol-var-log-xdmod
                   mountPath: /var/log/xdmod
           restartPolicy: Never
-          backoffLimit: 1
           volumes:
             - name: vol-xdmod-init
               configMap:

--- a/k8s/kube-base/cron-job-xdmod-openshift-prod.yaml
+++ b/k8s/kube-base/cron-job-xdmod-openshift-prod.yaml
@@ -7,6 +7,7 @@ spec:
   concurrencyPolicy: "Forbid"
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         spec:
           containers:
@@ -52,4 +53,3 @@ spec:
               persistentVolumeClaim:
                 claimName: pvc-xdmod-openshift-data
           restartPolicy: Never
-    backoffLimit: 1


### PR DESCRIPTION
The `backoffLimit` field was in the wrong place on both of the recently
added CronJob resources. This commit corrects than manifests to use
CronJob.spec.jobTemplate.spec.backoffLimit.

Closes: #90
