### PR TITLE
Removed unused volumeMounts in cron-job-xdmod-openshift-prod.yaml

### DIFF
--- a/k8s/kube-base/cron-job-xdmod-openshift-prod.yaml
+++ b/k8s/kube-base/cron-job-xdmod-openshift-prod.yaml
@@ -30,10 +30,6 @@ spec:
                   value: nerc_openshift_prod
               command: ["/usr/bin/xdmod-openshift-reporting.sh"]
               volumeMounts:
-                - name: vol-xdmod-conf
-                  mountPath: /etc/xdmod
-                - name: vol-xdmod-src
-                  mountPath: /usr/share/xdmod
                 - name: vol-xdmod-init
                   mountPath: /mnt/xdmod_init
                 - name: vol-var-log-xdmod


### PR DESCRIPTION
The XDMoD OpenShift prod job had some leftover volumeMounts that are not needed. This PR removes them.