### PR TITLE
removed the patches from the nerc-ocp-infra

### DIFF
--- a/k8s/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/k8s/overlays/nerc-ocp-infra/kustomization.yaml
@@ -3,6 +3,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 resources:
   - ../../xdmod-build
   - ../../kube-base
-patchesStrategicMerge:
-  - patches/bc-xdmod.yaml
-  - patches/bc-xdmod-dev.yaml

--- a/k8s/overlays/nerc-ocp-infra/patches/bc-xdmod-dev.yaml
+++ b/k8s/overlays/nerc-ocp-infra/patches/bc-xdmod-dev.yaml
@@ -1,9 +1,0 @@
-apiVersion: build.openshift.io/v1
-kind: BuildConfig
-metadata:
-  name: bc-xdmod-dev
-spec:
-  source:
-    type: Git
-    git:
-      ref: FixLostAndFound

--- a/k8s/overlays/nerc-ocp-infra/patches/bc-xdmod.yaml
+++ b/k8s/overlays/nerc-ocp-infra/patches/bc-xdmod.yaml
@@ -1,9 +1,0 @@
-apiVersion: build.openshift.io/v1
-kind: BuildConfig
-metadata:
-  name: bc-xdmod
-spec:
-  source:
-    type: Git
-    git:
-      ref: FixLostAndFound


### PR DESCRIPTION
These patches are no longer needed - but keeping the overlay inorder to have potential customizations in the future.