### PR TITLE
Update imagePullPolicy to Always

### DIFF
--- a/k8s/kube-base/cron-job-xdmod-ingestor.yaml
+++ b/k8s/kube-base/cron-job-xdmod-ingestor.yaml
@@ -12,7 +12,7 @@ spec:
           containers:
             - name: moc-xdmod
               image: moc-xdmod
-              imagePullPolicy: IfNotPresent
+              imagePullPolicy: Always
               command:
                 - "/usr/bin/xdmod-run-ingestor.sh"
               volumeMounts:

--- a/k8s/kube-base/cron-job-xdmod-openshift-prod.yaml
+++ b/k8s/kube-base/cron-job-xdmod-openshift-prod.yaml
@@ -13,7 +13,7 @@ spec:
           containers:
             - name: xdmod-openshift-prod-job
               image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod:latest
-              imagePullPolicy: IfNotPresent
+              imagePullPolicy: Always
               envFrom:
                 - secretRef:
                     name: xdmod-openshift-prod-secret


### PR DESCRIPTION
Since we are pulling the latest version of the image, it makes sense to use 'Always' as the imagePullPolicy as it allows these jobs to immediately grab updated images.