### PR TITLE
Adds missing copy of xdmod_init.json

### DIFF
--- a/k8s/kube-base/cron-job-xdmod-openshift-prod.yaml
+++ b/k8s/kube-base/cron-job-xdmod-openshift-prod.yaml
@@ -13,7 +13,7 @@ spec:
           containers:
             - name: xdmod-openshift-prod-job
               image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod:latest
-              imagePullPolicy: IfNotPresent
+              imagePullPolicy: Always
               envFrom:
                 - secretRef:
                     name: xdmod-openshift-prod-secret

--- a/k8s/kube-base/xdmod_init.json
+++ b/k8s/kube-base/xdmod_init.json
@@ -42,6 +42,11 @@
             "name": "nerc_openshift_staging",
             "formal_name": "NERC OpenShift Staging",
             "type": "hpc"
+        },
+        {
+            "name": "nerc_openshift_prod",
+            "formal_name": "NERC OpenShift Prod",
+            "type": "hpc"
         }
     ]
 }

--- a/xdmod-openshift-reporting.sh
+++ b/xdmod-openshift-reporting.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+cp /mnt/xdmod_init/xdmod_init.json /etc/xdmod/xdmod_init.json
 /usr/bin/xdmod-get-config-files 
 /usr/bin/sleep 30
 


### PR DESCRIPTION
The xdmod openshift script was missing xdmod_init.json, as it needs to be copied over. This PR fixes that.