### PR TITLE
Built xdmod open stack

### DIFF
--- a/Dockerfile.moc-xdmod
+++ b/Dockerfile.moc-xdmod
@@ -25,7 +25,7 @@ RUN yum makecache && \
     libreoffice \
     mariadb-server mariadb cronie logrotate \
     perl-Image-ExifTool php-mbstring php-pecl-apcu jq \
-    chromium-headless librsvg2-toolsm 
+    chromium-headless librsvg2-tools
 
 RUN yum clean all && \
     rm -rf /var/cache/yum

--- a/Dockerfile.moc-xdmod
+++ b/Dockerfile.moc-xdmod
@@ -25,7 +25,16 @@ RUN yum makecache && \
     libreoffice \
     mariadb-server mariadb cronie logrotate \
     perl-Image-ExifTool php-mbstring php-pecl-apcu jq \
-    chromium-headless librsvg2-tools
+    chromium-headless librsvg2-toolsm \
+    gcc openssl-devel bzip2-devel libffi-devel
+
+RUN mkdir /python-src && \
+    cd /python-src && \
+    wget https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tgz && \
+    tar -xzf Python-3.8.1.tgz && \
+    cd Python-3.8.1 && \
+    ./configure --enable-optimizations && \
+    make altinstall
 
 RUN yum clean all && \
     rm -rf /var/cache/yum

--- a/Dockerfile.moc-xdmod
+++ b/Dockerfile.moc-xdmod
@@ -25,16 +25,7 @@ RUN yum makecache && \
     libreoffice \
     mariadb-server mariadb cronie logrotate \
     perl-Image-ExifTool php-mbstring php-pecl-apcu jq \
-    chromium-headless librsvg2-toolsm \
-    gcc openssl-devel bzip2-devel libffi-devel
-
-RUN mkdir /python-src && \
-    cd /python-src && \
-    wget https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tgz && \
-    tar -xzf Python-3.8.1.tgz && \
-    cd Python-3.8.1 && \
-    ./configure --enable-optimizations && \
-    make altinstall
+    chromium-headless librsvg2-toolsm 
 
 RUN yum clean all && \
     rm -rf /var/cache/yum

--- a/Dockerfile.xdmod-openstack
+++ b/Dockerfile.xdmod-openstack
@@ -1,0 +1,45 @@
+# Dependencies needed by XDMoD
+FROM python:3.9.0
+
+
+# the python clients required to connect to openstack
+RUN apt-get update \
+    && apt-get install -y apt-transport-https \
+    && apt-get install -y default-mysql-client \
+    && apt-get install -y tar gzip \
+    && mkdir /app \
+    && pip3 install --upgrade pip \
+    && pip3 install keystoneauth python-keystoneclient python-novaclient python-cinderclient cryptography python-openstacksdk \
+    mysql mysql-connector-python-rf pexpect \
+    && pip3 install -I mysql-connector-python==8.0.29
+
+# openstack reporting
+COPY ./hypervisor_facts.py /app/xdmod-openstack-hypervisor
+COPY ./moc_openstack_api_reporting.py /app/xdmod-openstack-reporting
+COPY ./GetConfigFiles.py /app/xdmod-get-config-files
+COPY ./xdmod-run-ingestor.sh /app/xdmod-run-ingestor.sh
+COPY ./run-xdmod-openstack-hypervisor.sh /app/run-xdmod-openstack-hypervisor.sh
+COPY ./run-xdmod-openstack.sh /app/run-xdmod-openstack.sh 
+
+RUN chmod 774 /app/xdmod-openstack-hypervisor \
+    && sed -i -e 's/\r$//' /app/xdmod-openstack-hypervisor \
+    && chmod 774 /app/xdmod-openstack-reporting \
+    && sed -i -e 's/\r$//' /app/xdmod-openstack-reporting \ 
+    && chmod 774 /app/xdmod-get-config-files \
+    && sed -i -e 's/\r$//' /app/xdmod-get-config-files \ 
+    && chmod 774 /app/run-xdmod-openstack.sh \
+    && sed -i -e 's/\r$//' /app/run-xdmod-openstack.sh \ 
+    && chmod 774 /app/run-xdmod-openstack-hypervisor.sh \
+    && sed -i -e 's/\r$//' /app/run-xdmod-openstack-hypervisor.sh \
+    && chmod -R g+rwx /app \
+    && chgrp -R 0 /app 
+
+# force downgrade of mysql-connector-python
+# https://stackoverflow.com/questions/73244027/character-set-utf8-unsupported-in-python-mysql-connector
+RUN pip3 install -I mysql-connector-python==8.0.29
+
+EXPOSE 8080
+
+CMD ["/app/run-xdmod-openstack.sh"]
+
+WORKDIR /

--- a/Dockerfile.xdmod-openstack
+++ b/Dockerfile.xdmod-openstack
@@ -1,8 +1,6 @@
-# Dependencies needed by XDMoD
+# Dockerfile to run python scripts to pull data from openstack
 FROM python:3.9.0
 
-
-# the python clients required to connect to openstack
 RUN apt-get update \
     && apt-get install -y apt-transport-https \
     && apt-get install -y default-mysql-client \
@@ -13,7 +11,6 @@ RUN apt-get update \
     mysql mysql-connector-python-rf pexpect \
     && pip3 install -I mysql-connector-python==8.0.29
 
-# openstack reporting
 COPY ./hypervisor_facts.py /app/xdmod-openstack-hypervisor
 COPY ./moc_openstack_api_reporting.py /app/xdmod-openstack-reporting
 COPY ./GetConfigFiles.py /app/xdmod-get-config-files
@@ -33,10 +30,6 @@ RUN chmod 774 /app/xdmod-openstack-hypervisor \
     && sed -i -e 's/\r$//' /app/run-xdmod-openstack-hypervisor.sh \
     && chmod -R g+rwx /app \
     && chgrp -R 0 /app 
-
-# force downgrade of mysql-connector-python
-# https://stackoverflow.com/questions/73244027/character-set-utf8-unsupported-in-python-mysql-connector
-RUN pip3 install -I mysql-connector-python==8.0.29
 
 EXPOSE 8080
 

--- a/GetConfigFiles.py
+++ b/GetConfigFiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/local/bin/python3
 """ This pulls the config files from the database and copies them in to /etc/xdmod
 
     Will be unnecessary if RWX volumes become available
@@ -62,7 +62,7 @@ def main():
         print(f"errors: {b64_err}")
         with open("/etc/xdmod/etc_xdmod.tgz", "wb") as fptr:
             fptr.write(b64_out)
-        os.system("/usr/bin/tar -xzf /etc/xdmod/etc_xdmod.tgz")
+        os.system("/bin/tar -xzf /etc/xdmod/etc_xdmod.tgz --directory /")
 
     cnx.commit()
     cnx.close()

--- a/k8s/xdmod-build/bc-xdmod-openstack.yaml
+++ b/k8s/xdmod-build/bc-xdmod-openstack.yaml
@@ -1,0 +1,24 @@
+piVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: bc-xdmod
+spec:
+  runPolicy: Serial
+  source:
+    type: Git
+    git:
+      uri: https://github.com/CCI-MOC/xdmod-cntr.git
+    contextDir: /
+  strategy:
+    type: Docker
+    dockerStrategy:
+      from:
+        kind: DockerImage
+        name: python-3.9.0
+      dockerfilePath: Dockerfile.xdmod-openstack
+  output:
+    to:
+      kind: ImageStreamTag
+      name: xdmod-openstack:latest
+  triggers:
+    - type: ConfigChange

--- a/k8s/xdmod-build/bc-xdmod-openstack.yaml
+++ b/k8s/xdmod-build/bc-xdmod-openstack.yaml
@@ -1,4 +1,4 @@
-piVersion: build.openshift.io/v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: bc-xdmod

--- a/k8s/xdmod-build/is-xdmod-openstack.yaml
+++ b/k8s/xdmod-build/is-xdmod-openstack.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    app: xdmod-openstack
+  name: xdmod-openstack
+  namespace: xdmod
+spec:
+  lookupPolicy:
+    local: true

--- a/moc_openstack_api_reporting.py
+++ b/moc_openstack_api_reporting.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/local/bin/python3
 """ This is intended to poll openstack for changes to be reported in xdmod """
 # pylint: disable=line-too-long chained-comparison too-many-locals
 

--- a/run-xdmod-openstack.sh
+++ b/run-xdmod-openstack.sh
@@ -1,8 +1,7 @@
-#!/usr/bin/sh
+#!/bin/bash
 
 cp /mnt/xdmod_init/xdmod_init.json /etc/xdmod/xdmod_init.json
-/usr/bin/xdmod-get-config-files 
+/app/xdmod-get-config-files 
+cp /etc/xdmod/clouds.yaml /etc/openstack/clouds.yaml
 cd /data
-xdmod-openstack-reporting
-xdmod-shredder
- 
+/app/xdmod-openstack-reporting --cloud $OPENSTACK_INSTANCE


### PR DESCRIPTION
This for building the xdmod-openstack container using a build config from and a docker file that uses python 3.9 as it's base.  Major difference being that xdmod is based on centos7 and python 3.9 is based on ubuntu.