### PR TITLE
Deploy bc xdmod openstack

### DIFF
--- a/k8s/xdmod-build/bc-xdmod-openstack.yaml
+++ b/k8s/xdmod-build/bc-xdmod-openstack.yaml
@@ -1,7 +1,7 @@
 apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
-  name: bc-xdmod
+  name: bc-xdmod-openstack
 spec:
   runPolicy: Serial
   source:

--- a/k8s/xdmod-build/bc-xdmod-openstack.yaml
+++ b/k8s/xdmod-build/bc-xdmod-openstack.yaml
@@ -14,7 +14,7 @@ spec:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: python-3.9.0
+        name: python:3.9.0
       dockerfilePath: Dockerfile.xdmod-openstack
   output:
     to:

--- a/k8s/xdmod-build/kustomization.yaml
+++ b/k8s/xdmod-build/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - is-xdmod.yaml
   - bc-xdmod-dev.yaml
   - is-xdmod-dev.yaml
+  - bc-xdmod-openstack.yaml
+  - is-xdmod-openstack.yaml


### PR DESCRIPTION
This deploys the build config using kustomize so that the xdmod-openstack container can be built on the NERC.