### PR TITLE
Deploy Shred Job

### DIFF
--- a/k8s/kube-base/cj-xdmod-openstack-shred.yaml
+++ b/k8s/kube-base/cj-xdmod-openstack-shred.yaml
@@ -9,12 +9,47 @@ spec:
     spec:
       template:
         spec:
+          initContainers:
+            - name: cj-init-xdmod-openstack
+              image: xdmod-openstack
+              resources:
+                requests:
+                  memory: "1Gi"
+                limits:
+                  memory: "2Gi"
+              imagePullPolicy: Always
+              command:
+                - "/app/run-xdmod-openstack.sh"
+              env:
+                - name: OPENSTACK_INSTANCE
+                  value: "nerc-openstack"
+              volumeMounts:
+                - name: vol-xdmod-conf
+                  mountPath: /etc/xdmod
+                - name: vol-clouds-yaml
+                  mountPath: /etc/openstack
+                - name: vol-xdmod-init
+                  mountPath: /mnt/xdmod_init
+                - name: vol-var-log-xdmod
+                  mountPath: /var/log/xdmod
+                - name: vol-openstack-data
+                  mountPath: /data
           containers:
             - name: cj-xdmod-openstack
               image: moc-xdmod
               imagePullPolicy: Always
               command:
-                - "/usr/bin/run-xdmod-openstack.sh"
+                - xdmod-shredder
+              args:
+                [
+                  "--debug",
+                  "-f",
+                  "openstack",
+                  "-d",
+                  "/data",
+                  "-r",
+                  "nerc-openstack",
+                ]
               volumeMounts:
                 - name: vol-xdmod-conf
                   mountPath: /etc/xdmod

--- a/k8s/kube-base/kustomization.yaml
+++ b/k8s/kube-base/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - route-xdmod.yaml
   - cron-job-xdmod-ingestor.yaml
   - cron-job-xdmod-openshift-prod.yaml
+  - cj-xdmod-opestack-shred.yaml
 
 configMapGenerator:
   - name: cm-xdmod-init-json

--- a/k8s/overlays/nerc-ocp-infra/patches/cj-xdmod-openstack-shred.yaml
+++ b/k8s/overlays/nerc-ocp-infra/patches/cj-xdmod-openstack-shred.yaml
@@ -1,0 +1,32 @@
+piVersion: batch/v1beata1
+kind: CronJob
+metadata:
+  name: cj-xdmod-openstack
+spec:
+  schedule: "0/20 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          initContainers:
+            - name: cj-init-xdmod-openstack
+              env:
+                - name: OPENSTACK_INSTANCE
+                  value: "nerc-openstack"
+          containers:
+            - name: cj-xdmod-openstack
+              image: moc-xdmod
+              imagePullPolicy: Always
+              command:
+                - xdmod-shredder
+              args:
+                [
+                  "--debug",
+                  "-f",
+                  "openstack",
+                  "-d",
+                  "/data",
+                  "-r",
+                  "nerc-openstack",
+                ]


### PR DESCRIPTION
These are the files to deploy the openstack shredding job. 1) the configuration is loaded from the database via the init container 2) The data from openstack is loaded into the PV in the init container 3) xdmod-shredder is run in the container.

This was done as we don't yet support RWX persistent volumes and the xdmod team is still on centos 7 which uses an older version of of python of which they are planning to update to a current version of python.

I would like to patch the args to the command in the overlay/nerc-ocp-infra patch directory, but seem to be hitting https://github.com/kubernetes-sigs/kustomize/issues/4062