### PR TITLE
Fixed a typo in the kustomization yaml

### DIFF
--- a/k8s/kube-base/kustomization.yaml
+++ b/k8s/kube-base/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
   - route-xdmod.yaml
   - cron-job-xdmod-ingestor.yaml
   - cron-job-xdmod-openshift-prod.yaml
-  - cj-xdmod-opestack-shred.yaml
+  - cj-xdmod-openstack-shred.yaml
 
 configMapGenerator:
   - name: cm-xdmod-init-json


### PR DESCRIPTION
Since I misspelled the name of the cron job, it was not loading onto nerc production (dropped the n in openstack).