### PR TITLE
Correcting the indentation of backoffLimit

### DIFF
--- a/k8s/kube-base/cj-xdmod-openstack-shred.yaml
+++ b/k8s/kube-base/cj-xdmod-openstack-shred.yaml
@@ -7,6 +7,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         spec:
           initContainers:
@@ -62,7 +63,6 @@ spec:
                 - name: vol-openstack-data
                   mountPath: /data
           restartPolicy: Never
-          backoffLimit: 1
           volumes:
             - name: vol-xdmod-init
               configMap:


### PR DESCRIPTION
Same error as was found in the xdmod-openshift.  Got the error from argoCD that it didn't recognize backoffLimit.