### PR TITLE
Qualifying the local registry for the moc-xdmod* images

### DIFF
--- a/k8s/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/k8s/overlays/nerc-ocp-infra/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
 
 patchesStrategicMerge:
   - patches/cj-xdmod-openstack-shred.yaml
+  - patches/deployment-xdmod.yaml

--- a/k8s/overlays/nerc-ocp-infra/patches/deployment-xdmod.yaml
+++ b/k8s/overlays/nerc-ocp-infra/patches/deployment-xdmod.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: xdmod-ui
+  labels:
+    component: xdmod-ui
+spec:
+  selector:
+    matchLabels:
+      component: xdmod-ui
+  template:
+    metadata:
+      labels:
+        component: xdmod-ui
+    spec:
+      containers:
+        - image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod:latest
+          name: xdmod
+      initContainers:
+        - image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod-dev:latest
+          name: xdmod-init-1
+        - image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod:latest
+          name: xdmod-init-2


### PR DESCRIPTION
This is to test a work-a-round for the following issue:

    https://github.com/OCP-on-NERC/operations/issues/80

I have occasionally had to do this in the past and I am not certain why I didn't have to do this before the cluster rebuild.  I do prefer to not qualify the local registry.