### PR TITLE
Added the entire deployment to the patch

### DIFF
--- a/k8s/overlays/nerc-ocp-infra/patches/deployment-xdmod.yaml
+++ b/k8s/overlays/nerc-ocp-infra/patches/deployment-xdmod.yaml
@@ -8,6 +8,8 @@ spec:
   selector:
     matchLabels:
       component: xdmod-ui
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -16,8 +18,106 @@ spec:
       containers:
         - image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod:latest
           name: xdmod
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: vol-xdmod-conf
+              mountPath: /etc/xdmod
+            - name: vol-xdmod-src
+              mountPath: /usr/share/xdmod
+            - name: vol-xdmod-data
+              mountPath: /root/xdmod_data
+            - name: vol-httpd-conf
+              mountPath: /etc/httpd
+            - name: vol-clouds-yaml
+              mountPath: /etc/openstack
+            - name: vol-httpd-conf
+              mountPath: /root/httpd
+            - name: vol-var-log-xdmod
+              mountPath: /var/log/xdmod
+            - name: vol-var-log-httpd
+              mountPath: /var/log/httpd
+            - name: vol-run-httpd
+              mountPath: /run/httpd
+            - name: vol-php-session
+              mountPath: /var/lib/php/session
       initContainers:
         - image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod-dev:latest
           name: xdmod-init-1
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/usr/bin/xdmod-init"
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: vol-xdmod-conf
+              mountPath: /mnt/xdmod_conf
+            - name: vol-clouds-yaml
+              mountPath: /mnt/clouds
+            - name: vol-httpd-conf
+              mountPath: /mnt/httpd_conf
+            - name: vol-xdmod-src
+              mountPath: /mnt/xdmod_src
+            - name: vol-xdmod-data
+              mountPath: /root/xdmod_data
+            - name: vol-httpd-cm
+              mountPath: /root/httpd
+            - name: vol-xdmod-init
+              mountPath: /root/xdmod_init
         - image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod:latest
           name: xdmod-init-2
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/usr/bin/xdmod-init"
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: vol-xdmod-conf
+              mountPath: /etc/xdmod
+            - name: vol-xdmod-src
+              mountPath: /usr/share/xdmod
+            - name: vol-xdmod-data
+              mountPath: /root/xdmod_data
+            - name: vol-httpd-conf
+              mountPath: /etc/httpd
+            - name: vol-clouds-yaml
+              mountPath: /etc/openstack
+            - name: vol-httpd-conf
+              mountPath: /root/httpd
+      volumes:
+        - name: vol-xdmod-conf
+          persistentVolumeClaim:
+            claimName: pvc-xdmod-conf
+        - name: vol-clouds-yaml
+          persistentVolumeClaim:
+            claimName: pvc-clouds-yaml
+        - name: vol-httpd-conf
+          persistentVolumeClaim:
+            claimName: pvc-httpd-conf
+        - name: vol-xdmod-src
+          persistentVolumeClaim:
+            claimName: pvc-xdmod-src
+        - name: vol-xdmod-data
+          persistentVolumeClaim:
+            claimName: pvc-xdmod-data
+        - name: vol-var-log-xdmod
+          emptyDir: {}
+        - name: vol-var-log-httpd
+          emptyDir: {}
+        - name: vol-run-httpd
+          emptyDir: {}
+        - name: vol-php-session
+          emptyDir: {}
+        - name: vol-xdmod-init
+          configMap:
+            items:
+              - key: xdmod_init.json
+                path: xdmod_init.json
+            name: cm-xdmod-init-json
+        - name: vol-httpd-cm
+          configMap:
+            items:
+              - key: httpd.conf
+                path: httpd.conf
+            name: cm-httpd-conf


### PR DESCRIPTION
As I am getting the following in the log files of the first init container (xdmod-init-1)  (currently that system is being reinstalled):

  (13)Permission denied: AH00072: make_sock: could not bind to address [::]:80
  (13)Permission denied: AH00072: make_sock: could not bind to address 0.0.0.0:80
  no listening sockets available, shutting down
  AH00015: Unable to open logs

This implies 2 things:

  1) kustomize is forgetting or patching over the command in the initial deployment
     as it is using the command for the docker conatiner as opposed to the one specified in
     the deployment.

  2) kustomize is probably patching over the entire container spec as it is not mounting
     the other directories, as an emphemerial disk is mounted to the log directory making
     it writeable.

As such, I am including the entire defintiion for all of the containers in the patch.