### PR TITLE
Refactor shredder job

### DIFF
--- a/Dockerfile.moc-xdmod
+++ b/Dockerfile.moc-xdmod
@@ -74,7 +74,6 @@ RUN rm -f /etc/httpd/conf.d/ssl.conf \
 # openstack reporting
 COPY ./hypervisor_facts.py /usr/bin/xdmod-openstack-hypervisor
 COPY ./moc_openstack_api_reporting.py /usr/bin/xdmod-openstack-reporting
-COPY ./GetConfigFiles.py /usr/bin/xdmod-get-config-files
 COPY ./run-xdmod-openstack.sh /usr/bin/run-xdmod-openstack.sh
 COPY ./xdmod_init.py /usr/bin/xdmod-init 
 COPY ./run-xdmod-openstack-hypervisor.sh /usr/bin/run-xdmod-openstack-hypervisor.sh
@@ -84,8 +83,6 @@ RUN chmod 774 /usr/bin/xdmod-openstack-hypervisor \
     && sed -i -e 's/\r$//' /usr/bin/xdmod-openstack-reporting \ 
     && chmod 774 /usr/bin/xdmod-init \
     && sed -i -e 's/\r$//' /usr/bin/xdmod-init \ 
-    && chmod 774 /usr/bin/xdmod-get-config-files \
-    && sed -i -e 's/\r$//' /usr/bin/xdmod-get-config-files \ 
     && chmod 774 /usr/bin/run-xdmod-openstack.sh \
     && sed -i -e 's/\r$//' /usr/bin/run-xdmod-openstack.sh \ 
     && chmod 774 /usr/bin/run-xdmod-openstack-hypervisor.sh \

--- a/moc_openstack_api_reporting.py
+++ b/moc_openstack_api_reporting.py
@@ -530,8 +530,9 @@ def process_compute_events(openstack_conn, script_datetime, openstack_data, clus
 
         if server["instance_id"] not in cluster_state["vm_timestamps"]:
             cluster_state["vm_timestamps"][server["instance_id"]] = {}
-        cluster_state["vm_timestamps"][server["instance_id"]]["timestamp"] = event_data["event_time"]
-        cluster_state["vm_timestamps"][server["instance_id"]]["updated"] = 1
+        if event_data["event_time"]:
+            cluster_state["vm_timestamps"][server["instance_id"]]["timestamp"] = event_data["event_time"]
+            cluster_state["vm_timestamps"][server["instance_id"]]["updated"] = 1
 
         if server["state"] == "DELETED":
             del cluster_state["vm_timestamps"][server["instance_id"]]

--- a/moc_openstack_api_reporting.py
+++ b/moc_openstack_api_reporting.py
@@ -485,7 +485,6 @@ def events_to_event_by_date(event_list):
 
 def process_compute_events(openstack_conn, script_datetime, openstack_data, cluster_state):
     """collects and processes event data"""
-    event_data_defined = 0
     events_by_date = {}
     openstack_nova = nova_client.Client(2, session=openstack_conn.session)
 
@@ -498,6 +497,7 @@ def process_compute_events(openstack_conn, script_datetime, openstack_data, clus
     last_run_datetime = datetime.datetime.fromisoformat(cluster_state["last_run_timestamp"])
 
     for server in openstack_data["server_dict"].values():
+        event_data_defined = 0
         # need to generate an existence event for each server in server_dict
         if server["state"] == "ACTIVE" or server["state"] == "DELETED":
             event_data = {

--- a/moc_openstack_api_reporting.py
+++ b/moc_openstack_api_reporting.py
@@ -530,7 +530,7 @@ def process_compute_events(openstack_conn, script_datetime, openstack_data, clus
 
         if server["instance_id"] not in cluster_state["vm_timestamps"]:
             cluster_state["vm_timestamps"][server["instance_id"]] = {}
-        if event_data["event_time"]:
+        if event_data and event_data["event_time"]:
             cluster_state["vm_timestamps"][server["instance_id"]]["timestamp"] = event_data["event_time"]
             cluster_state["vm_timestamps"][server["instance_id"]]["updated"] = 1
 

--- a/run-xdmod-openstack.sh
+++ b/run-xdmod-openstack.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-cp /mnt/xdmod_init/xdmod_init.json /etc/xdmod/xdmod_init.json
-/app/xdmod-get-config-files 
-cp /etc/xdmod/clouds.yaml /etc/openstack/clouds.yaml
 cd /data
 /app/xdmod-openstack-reporting --cloud $OPENSTACK_INSTANCE


### PR DESCRIPTION
This is a refactoring of the shredder job using a separate init container to download the configuration from the database as we currently do not have the facility to support RWX persistent volumes.

Furthermore, if and when we do get RWX persistent volumes, it should be an easy change to remove the init container.