### PR TITLE
Specify the local repo in order to find the image

### DIFF
--- a/k8s/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/k8s/overlays/nerc-ocp-infra/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
 
 patchesStrategicMerge:
   - patches/cj-xdmod-openstack-shred.yaml
+  - patches/cj-xdmod-ingestor.yaml
   - patches/deployment-xdmod.yaml

--- a/k8s/overlays/nerc-ocp-infra/patches/cj-xdmod-ingestor.yaml
+++ b/k8s/overlays/nerc-ocp-infra/patches/cj-xdmod-ingestor.yaml
@@ -1,0 +1,17 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: xdmod-ingestor
+spec:
+  schedule: "@daily"
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          initContainers:
+            - name: download-config
+              image: image-registry.openshift-image-registry.svc:5000/xdmod/xdmod-openstack
+          containers:
+            - name: moc-xdmod
+              image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod

--- a/k8s/overlays/nerc-ocp-infra/patches/cj-xdmod-openstack-shred.yaml
+++ b/k8s/overlays/nerc-ocp-infra/patches/cj-xdmod-openstack-shred.yaml
@@ -16,7 +16,7 @@ spec:
                   value: "nerc-openstack"
           containers:
             - name: cj-xdmod-openstack
-              image: moc-xdmod
+              image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod
               imagePullPolicy: Always
               command:
                 - xdmod-shredder


### PR DESCRIPTION
This way openstack will pull from the local repo as opposed to trying to pull from somewhere else and failing.  The containers found in this job are build locally from the build configs.