### PR TITLE
Specifies OpenShift Interanl Registry for the Init Container Image

### DIFF
--- a/k8s/overlays/nerc-ocp-infra/patches/cj-xdmod-openstack-shred.yaml
+++ b/k8s/overlays/nerc-ocp-infra/patches/cj-xdmod-openstack-shred.yaml
@@ -11,6 +11,7 @@ spec:
         spec:
           initContainers:
             - name: cj-init-xdmod-openstack
+              image: image-registry.openshift-image-registry.svc:5000/xdmod/xdmod-openstack
               env:
                 - name: OPENSTACK_INSTANCE
                   value: "nerc-openstack"


### PR DESCRIPTION
There is one more image that needs to be pulled from the local registry and is blocking the shredder job from running (as openshift is unable to pull the image)

Here is the error message from the logs that this is expected solve:

```
oc logs cj-xdmod-openstack-27911400-jfskx -c cj-init-xdmod-openstack
Error from server (BadRequest): container "cj-init-xdmod-openstack" in pod "cj-xdmod-openstack-27911400-jfskx" is waiting to start: trying and failing to pull image
```

Note, this was not occurring before the rebuilds on the infra cluster and is not currently needed on ocp-staging.

