### PR TITLE
Remove google chrome from the moc-xdmod docker image

### DIFF
--- a/Dockerfile.moc-xdmod
+++ b/Dockerfile.moc-xdmod
@@ -10,7 +10,6 @@ RUN yum makecache && \
     expect \
     gcc-c++ \
     gnu-free-sans-fonts \
-    google-chrome-stable \
     npm \
     openssl \
     postfix \ 

--- a/Dockerfile.moc-xdmod
+++ b/Dockerfile.moc-xdmod
@@ -1,8 +1,6 @@
 FROM centos:7.9.2009
 ENV BRANCH=xdmod10.0
 
-COPY assets/google-chrome.repo /etc/yum.repos.d
-
 # Dependencies needed by XDMoD
 RUN yum makecache && \
     yum -y install epel-release centos-release-scl-rh && \

--- a/assets/google-chrome.repo
+++ b/assets/google-chrome.repo
@@ -1,6 +1,0 @@
-[google-chrome]
-name=google-chrome - \$basearch
-baseurl=http://dl.google.com/linux/chrome/rpm/stable/\$basearch
-enabled=1
-gpgcheck=1
-gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub


### PR DESCRIPTION
As google chrome is only used to run their UI tests and we are not yet developing anything related to the UI so we don't need to refer to google chorme in the dockerfile.