### PR TITLE
The resource has an '_' where as the cloud config has a '-'

### DIFF
--- a/k8s/overlays/nerc-ocp-infra/patches/cj-xdmod-openstack-shred.yaml
+++ b/k8s/overlays/nerc-ocp-infra/patches/cj-xdmod-openstack-shred.yaml
@@ -29,5 +29,5 @@ spec:
                   "-d",
                   "/data",
                   "-r",
-                  "nerc-openstack",
+                  "nerc_openstack",
                 ]

--- a/k8s/overlays/nerc-ocp-staging/patches/cj-xdmod-openstack-shred.yaml
+++ b/k8s/overlays/nerc-ocp-staging/patches/cj-xdmod-openstack-shred.yaml
@@ -28,5 +28,5 @@ spec:
                   "-d",
                   "/data",
                   "-r",
-                  "nerc-openstack",
+                  "nerc_openstack",
                 ]


### PR DESCRIPTION
This fix should fix this error:

    "Failed to create shredder: No config found for 'nerc-openstack' in '/etc/xdmod/resources.json'"

The resrouce is refered to as nerc_openstack, where as the cloud config uses nerc-openstack.  Keep in mind:

1) the cloud config (as defined in /etc/openstack/clouds.yaml) is used in the init container 2) the resource (as defined in /etc/xdmod/resources.json)  is used by the shredder.