### PR TITLE
Added workflow to validate manifests

### DIFF
--- a/.github/workflows/validate-manifests.yaml
+++ b/.github/workflows/validate-manifests.yaml
@@ -1,0 +1,24 @@
+name: Kustomize build overlays
+
+on:
+  pull_request:
+    paths:
+      - '**.yaml'
+
+jobs:
+  validate-manifests:
+    runs-on: ubuntu-latest
+    env:
+      KUSTOMIZE_VERSION: v4.5.5
+      TERM: xterm-256color
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Pull kustomize image
+        run: |
+          docker pull k8s.gcr.io/kustomize/kustomize:${KUSTOMIZE_VERSION}
+      - name: Validate manifests
+        run: |
+          export KUSTOMIZE="docker run --rm -v $PWD:$PWD -w $PWD k8s.gcr.io/kustomize/kustomize:${KUSTOMIZE_VERSION}"
+          ./ci/validate-manifests.sh

--- a/ci/validate_manifests.sh
+++ b/ci/validate_manifests.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+: "${KUSTOMIZE:=kustomize}"
+
+find_overlays() {
+    find . -regex '.*/overlays/[^/]*/kustomization.yaml' -exec dirname {} \;
+}
+
+okay() {
+    echo -n "$(tput setaf 2)${1}:okay$(tput sgr0) "
+}
+
+fail() {
+    echo "$(tput setaf 1)${1}:failed$(tput sgr0)"
+    [[ -s "$tmpdir/stdout" ]] && { echo; cat $tmpdir/stdout; }
+    [[ -s "$tmpdir/stderr" ]] && { echo; cat $tmpdir/stderr; }
+    exit 1
+}
+
+tmpdir=$(mktemp -d buildXXXXXX)
+trap "rm -rf $tmpdir" EXIT
+
+for overlay in $(find_overlays); do
+    : > "$tmpdir/stdout"
+
+    echo -n "$overlay "
+    if $KUSTOMIZE build "$overlay" > "$tmpdir/manifests.yaml" 2> "$tmpdir/stderr"; then
+        okay build
+    else
+        fail build
+    fi
+
+    echo
+done

--- a/k8s/overlays/CRC/kustomization.yaml
+++ b/k8s/overlays/CRC/kustomization.yaml
@@ -1,2 +1,2 @@
-bases:
-  - ../../base
+resources:
+  - ../../kube-base

--- a/k8s/overlays/minikube/kustomization.yaml
+++ b/k8s/overlays/minikube/kustomization.yaml
@@ -1,3 +1,2 @@
-bases:
-  - ../../base
-  - xdmod-ingress.yaml
+resources:
+  - ../../kube-base


### PR DESCRIPTION
Lifted from `OCP-on-NERC/nerc-ocp-config`, this is useful for finding errors that would prevent the manifests from being loaded.

Also fixed `minikube` and `CRC` overlays pointing to the wrong directory names or not existing files.