### PR TITLE
Removed extraneous commands from xdmod-openshift script

### DIFF
--- a/k8s/kube-base/cron-job-xdmod-openshift-prod.yaml
+++ b/k8s/kube-base/cron-job-xdmod-openshift-prod.yaml
@@ -53,6 +53,8 @@ spec:
                   mountPath: /var/log/xdmod
                 - name: vol-xdmod-openshift-data
                   mountPath: /data/xdmod_openshift_data
+                - name: vol-xdmod-conf
+                  mountPath: /etc/xdmod
           volumes:
             - name: vol-xdmod-init
               configMap:

--- a/xdmod-openshift-reporting.sh
+++ b/xdmod-openshift-reporting.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-cp /mnt/xdmod_init/xdmod_init.json /etc/xdmod/xdmod_init.json
-/usr/bin/xdmod-get-config-files 
 /usr/bin/sleep 30
 
 mkdir $OUTPUT_DIR


### PR DESCRIPTION
These commands are no longer needed now that the config is fetched in an init container