### PR TITLE
Work-A-Round for Running xdmod's acl-config

### DIFF
--- a/k8s/kube-base/deployment-xdmod.yaml
+++ b/k8s/kube-base/deployment-xdmod.yaml
@@ -45,10 +45,14 @@ spec:
         - image: moc-xdmod:latest
           name: xdmod-acl-work-a-round
           imagePullPolicy: IfNotPresent
-          command: ["/usr/bin/bash"]
-          args: ["-c", "while true; do /usr/bin/acl-config; sleep 420; done"]
-          ports:
-            - containerPort: 8080
+          command: 
+            - /bin/bash
+            - -c
+            - |
+              while true; do
+                /usr/bin/acl-config
+                sleep 420
+              done
           volumeMounts:
             - name: vol-xdmod-conf
               mountPath: /etc/xdmod

--- a/k8s/kube-base/deployment-xdmod.yaml
+++ b/k8s/kube-base/deployment-xdmod.yaml
@@ -42,6 +42,34 @@ spec:
               mountPath: /run/httpd
             - name: vol-php-session
               mountPath: /var/lib/php/session
+        - image: moc-xdmod:latest
+          name: xdmod-acl-work-a-round
+          imagePullPolicy: IfNotPresent
+          command: ["/usr/bin/bash"]
+          args: ["-c", "while true; do /usr/bin/acl-config; sleep 420; done"]
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: vol-xdmod-conf
+              mountPath: /etc/xdmod
+            - name: vol-xdmod-src
+              mountPath: /usr/share/xdmod
+            - name: vol-xdmod-data
+              mountPath: /root/xdmod_data
+            - name: vol-httpd-conf
+              mountPath: /etc/httpd
+            - name: vol-clouds-yaml
+              mountPath: /etc/openstack
+            - name: vol-httpd-conf
+              mountPath: /root/httpd
+            - name: vol-var-log-xdmod
+              mountPath: /var/log/xdmod
+            - name: vol-var-log-httpd
+              mountPath: /var/log/httpd
+            - name: vol-run-httpd
+              mountPath: /run/httpd
+            - name: vol-php-session
+              mountPath: /var/lib/php/session
       initContainers:
         - image: moc-xdmod-dev:latest
           name: xdmod-init-1


### PR DESCRIPTION
It seems that everytime the shredder run, the xdmod-ui interface gets stuck in the loading process.  This is either due to acl-config not running to completion on the shdredder pod, or acl-config modifying the config directory and scince the config directory is not shared RWX it doesn't updated on the xdmod-ui pod.

This will require more investigation as to what is occurng.  Meanwhile, this will run acl-config in the xdmod-ui pod every 7 minutes.  I'm trying to strike a balance between running acl-config too often (consumning too much database time) and keeping the UI from being stuck loading.