### PR TITLE
Refactoring Staging Deploy

### DIFF
--- a/k8s/overlays/nerc-ocp-staging/kustomization.yaml
+++ b/k8s/overlays/nerc-ocp-staging/kustomization.yaml
@@ -9,4 +9,6 @@ resources:
   - ../../kube-base
 
 patchesStrategicMerge:
+  - patches/cj-xdmod-ingestor.yaml
   - patches/cj-xdmod-openstack-shred.yaml
+  - patches/deployment-xdmod.yaml

--- a/k8s/overlays/nerc-ocp-staging/patches/cj-xdmod-ingestor.yaml
+++ b/k8s/overlays/nerc-ocp-staging/patches/cj-xdmod-ingestor.yaml
@@ -1,0 +1,17 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: xdmod-ingestor
+spec:
+  schedule: "@daily"
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          initContainers:
+            - name: download-config
+              image: image-registry.openshift-image-registry.svc:5000/xdmod-staging/xdmod-openstack
+          containers:
+            - name: moc-xdmod
+              image: image-registry.openshift-image-registry.svc:5000/xdmod-staging/moc-xdmod

--- a/k8s/overlays/nerc-ocp-staging/patches/cj-xdmod-openstack-shred.yaml
+++ b/k8s/overlays/nerc-ocp-staging/patches/cj-xdmod-openstack-shred.yaml
@@ -16,7 +16,7 @@ spec:
                   value: "nerc-openstack"
           containers:
             - name: cj-xdmod-openstack
-              image: moc-xdmod
+              image: image-registry.openshift-image-registry.svc:5000/xdmod-staging/moc-xdmod
               imagePullPolicy: Always
               command:
                 - xdmod-shredder

--- a/k8s/overlays/nerc-ocp-staging/patches/deployment-xdmod.yaml
+++ b/k8s/overlays/nerc-ocp-staging/patches/deployment-xdmod.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: xdmod-ui
+  labels:
+    component: xdmod-ui
+spec:
+  selector:
+    matchLabels:
+      component: xdmod-ui
+  template:
+    metadata:
+      labels:
+        component: xdmod-ui
+    spec:
+      containers:
+        - image: image-registry.openshift-image-registry.svc:5000/xdmod-staging/moc-xdmod:latest
+          name: xdmod
+      initContainers:
+        - image: image-registry.openshift-image-registry.svc:5000/xdmod-staging/moc-xdmod-dev:latest
+          name: xdmod-init-1
+        - image: image-registry.openshift-image-registry.svc:5000/xdmod-staging/moc-xdmod:latest
+          name: xdmod-init-2


### PR DESCRIPTION
apply the same changes made to the nerc infra deploy to the staging deploy (explicitly specifying open shifts internal registry to pull the images from).