### PR TITLE
Eliminate the xdmod-init-2 container

### DIFF
--- a/k8s/kube-base/deployment-xdmod.yaml
+++ b/k8s/kube-base/deployment-xdmod.yaml
@@ -97,26 +97,6 @@ spec:
               mountPath: /root/httpd
             - name: vol-xdmod-init
               mountPath: /root/xdmod_init
-        - image: moc-xdmod:latest
-          name: xdmod-init-2
-          imagePullPolicy: IfNotPresent
-          command:
-            - "/usr/bin/xdmod-init"
-          ports:
-            - containerPort: 8080
-          volumeMounts:
-            - name: vol-xdmod-conf
-              mountPath: /etc/xdmod
-            - name: vol-xdmod-src
-              mountPath: /usr/share/xdmod
-            - name: vol-xdmod-data
-              mountPath: /root/xdmod_data
-            - name: vol-httpd-conf
-              mountPath: /etc/httpd
-            - name: vol-clouds-yaml
-              mountPath: /etc/openstack
-            - name: vol-httpd-conf
-              mountPath: /root/httpd
       volumes:
         - name: vol-xdmod-conf
           persistentVolumeClaim:

--- a/k8s/overlays/nerc-ocp-infra/patches/deployment-xdmod.yaml
+++ b/k8s/overlays/nerc-ocp-infra/patches/deployment-xdmod.yaml
@@ -19,5 +19,3 @@ spec:
       initContainers:
         - image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod-dev:latest
           name: xdmod-init-1
-        - image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod:latest
-          name: xdmod-init-2

--- a/k8s/overlays/nerc-ocp-staging/patches/deployment-xdmod.yaml
+++ b/k8s/overlays/nerc-ocp-staging/patches/deployment-xdmod.yaml
@@ -19,5 +19,3 @@ spec:
       initContainers:
         - image: image-registry.openshift-image-registry.svc:5000/xdmod-staging/moc-xdmod-dev:latest
           name: xdmod-init-1
-        - image: image-registry.openshift-image-registry.svc:5000/xdmod-staging/moc-xdmod:latest
-          name: xdmod-init-2


### PR DESCRIPTION
This automatically runs xdmod-setup with the parameters given in xdmod_init.json.

Unfortunately, the xdmod team has an announcement of a new version that is not currently handled by the pexpect script, So this is a quick work-a-round until we can add the message to the pexpect script.