### PR TITLE
Change the unknow flavor's cpu, memory and disk values to 1

### DIFF
--- a/moc_openstack_api_reporting.py
+++ b/moc_openstack_api_reporting.py
@@ -393,9 +393,9 @@ def compile_server_state(server, project_dict, flavor_dict, user_dict):
     disk_gb = "0"
     ephemeral_gb = "0"
     instance_type = f"unknown flavor({server.flavor['id']})"
-    memory_mb = "0"
-    root_gb = "0"
-    vcpus = "0"
+    memory_mb = "1"
+    root_gb = "1"
+    vcpus = "1"
     if server.flavor["id"] in flavor_dict:
         disk_gb = str(flavor_dict[server.flavor["id"]]["disk"])
         ephemeral_gb = str(flavor_dict[server.flavor["id"]]["ephemeral"])


### PR DESCRIPTION
Xdmod cannot handle 0 for cpu. I have made mem and disk also 1 as I suspecit there are places where having 0 for these values may cause failure.