### PR TITLE
Added the internal registry to the acl work-a-round container

### DIFF
--- a/k8s/overlays/nerc-ocp-infra/patches/deployment-xdmod.yaml
+++ b/k8s/overlays/nerc-ocp-infra/patches/deployment-xdmod.yaml
@@ -16,6 +16,8 @@ spec:
       containers:
         - image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod:latest
           name: xdmod
+        - image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod:latest
+          name: xdmod-acl-work-a-round
       initContainers:
         - image: image-registry.openshift-image-registry.svc:5000/xdmod/moc-xdmod-dev:latest
           name: xdmod-init-1


### PR DESCRIPTION
Occasionally, OpenShift is not resolving images in its internal registry when it is trying to load an image that doesn't explictly specify the internal registry.

I am addressing this problem as it is a system specific issue, occasionally appearing on the nerc and not on ocp-staging.