### PR TITLE
Moved time of xdmod openshift cron job

### DIFF
--- a/k8s/kube-base/cron-job-xdmod-ingestor.yaml
+++ b/k8s/kube-base/cron-job-xdmod-ingestor.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: xdmod-ingestor
 spec:
-  schedule: "@daily"
+  schedule: "0 14 */1 * *"
   jobTemplate:
     spec:
       backoffLimit: 1

--- a/k8s/kube-base/cron-job-xdmod-openshift-prod.yaml
+++ b/k8s/kube-base/cron-job-xdmod-openshift-prod.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: xdmod-openshift-prod-job
 spec:
-  schedule: "0 1 */1 * *"
+  schedule: "0 13 */1 * *"
   concurrencyPolicy: "Forbid"
   jobTemplate:
     spec:


### PR DESCRIPTION
The job currently runs at 1am; however 1am server time is apparently 9pm the previous day OpenShift time. Changing the time to 1pm will allow the job to get all the data for the previous day.